### PR TITLE
Add communication with JetBrains tools

### DIFF
--- a/REUSE.md
+++ b/REUSE.md
@@ -1,0 +1,73 @@
+# IntelliJ Plugin Functions and Tools for JetBrains Integration
+
+This document provides an overview of the functions of each IntelliJ plugin in the `reified/ofac` directory and details about the tools needed for JetBrains integration.
+
+## Bumblebee
+
+### Plugin Functions
+- Provides AST transformations for various programming languages.
+- Includes transformations like Anonymization, Augmented Assignment, Comments Removal, and more.
+
+### Tools Needed
+- IntelliJ IDEA Community Edition
+- Kotlin
+- Gradle
+
+## CodeShell
+
+### Plugin Functions
+- Enhances code navigation and refactoring capabilities.
+- Provides features like code snippets, code generation, and more.
+
+### Tools Needed
+- IntelliJ IDEA Community Edition
+- Kotlin
+- Gradle
+
+## DevoxxGenie
+
+### Plugin Functions
+- Integrates with various AI models for code generation and completion.
+- Supports models like OpenAI, Anthropic, Bedrock, and more.
+
+### Tools Needed
+- IntelliJ IDEA Community Edition
+- Kotlin
+- Gradle
+
+## EM-guide
+
+### Plugin Functions
+- Provides tools for extracting and refactoring methods in code.
+- Supports various programming languages and frameworks.
+
+### Tools Needed
+- IntelliJ IDEA Community Edition
+- Kotlin
+- Gradle
+
+## PSIMiner
+
+### Plugin Functions
+- Analyzes and extracts information from PSI trees.
+- Supports various programming languages and provides different extraction methods.
+
+### Tools Needed
+- IntelliJ IDEA Community Edition
+- Kotlin
+- Gradle
+
+## RooCode
+
+### Plugin Functions
+- Provides various code analysis and transformation tools.
+- Supports multiple programming languages and frameworks.
+- source for forward-looking enhancement to bao-cline
+ 
+tools: VSCode,ts
+
+## Bao-Cline
+
+### Plugin Functions
+- Provides a fork of  `roocode` in VSCode and pursues JetBrains Community Edition tools psi and ast interaction.
+- Includes methods for connecting to, sending messages to, and receiving messages from JetBrains tools using the `JetBrainsCommunicator` class.

--- a/reified/Bao-Cline/.vscode/extensions.json
+++ b/reified/Bao-Cline/.vscode/extensions.json
@@ -4,6 +4,11 @@
 	"recommendations": [
 		"dbaeumer.vscode-eslint",
 		"connor4312.esbuild-problem-matchers",
-		"ms-vscode.extension-test-runner"
+		"ms-vscode.extension-test-runner",
+		"JetBrains.jetbrains-toolbox",
+		"JetBrains.intellij-idea-community",
+		"JetBrains.intellij-idea-ultimate",
+		"JetBrains.intellij-idea-educational",
+		"JetBrains.intellij-idea-ce"
 	]
 }

--- a/reified/Bao-Cline/src/core/webview/ClineProvider.ts
+++ b/reified/Bao-Cline/src/core/webview/ClineProvider.ts
@@ -23,6 +23,7 @@ import { openMention } from "../mentions"
 import { getNonce } from "./getNonce"
 import { getUri } from "./getUri"
 import { playSound, setSoundEnabled, setSoundVolume } from "../../utils/sound"
+import { JetBrainsCommunicator } from "../../integrations/jetbrains/JetBrainsCommunicator"
 
 /*
 https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -618,6 +619,22 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						const debugDiffEnabled = message.bool ?? false
 						await this.updateGlobalState("debugDiffEnabled", debugDiffEnabled)
 						await this.postStateToWebview()
+						break
+					case "connectToJetBrains":
+						const jetBrainsCommunicator = new JetBrainsCommunicator()
+						await jetBrainsCommunicator.connect()
+						this.outputChannel.appendLine("Connected to JetBrains tools")
+						break
+					case "sendMessageToJetBrains":
+						const jetBrainsCommunicatorSend = new JetBrainsCommunicator()
+						await jetBrainsCommunicatorSend.sendMessage(message.text!)
+						this.outputChannel.appendLine(`Message sent to JetBrains tools: ${message.text}`)
+						break
+					case "receiveMessageFromJetBrains":
+						const jetBrainsCommunicatorReceive = new JetBrainsCommunicator()
+						const receivedMessage = await jetBrainsCommunicatorReceive.receiveMessage()
+						this.outputChannel.appendLine(`Message received from JetBrains tools: ${receivedMessage}`)
+						await this.postMessageToWebview({ type: "jetBrainsMessage", text: receivedMessage })
 						break
 				}
 			},

--- a/reified/Bao-Cline/src/exports/index.ts
+++ b/reified/Bao-Cline/src/exports/index.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import { ClineProvider } from "../core/webview/ClineProvider"
 import { ClineAPI } from "./cline"
+import { JetBrainsCommunicator } from "../integrations/jetbrains/JetBrainsCommunicator"
 
 export function createClineAPI(outputChannel: vscode.OutputChannel, sidebarProvider: ClineProvider): ClineAPI {
 	const api: ClineAPI = {
@@ -55,6 +56,32 @@ export function createClineAPI(outputChannel: vscode.OutputChannel, sidebarProvi
 				type: "invoke",
 				invoke: "secondaryButtonClick",
 			})
+		},
+
+		// New methods for JetBrains tools integration
+		connectToJetBrains: async () => {
+			const communicator = new JetBrainsCommunicator()
+			await communicator.connect()
+			outputChannel.appendLine("Connected to JetBrains tools")
+		},
+
+		disconnectFromJetBrains: async () => {
+			const communicator = new JetBrainsCommunicator()
+			await communicator.disconnect()
+			outputChannel.appendLine("Disconnected from JetBrains tools")
+		},
+
+		sendMessageToJetBrains: async (message: string) => {
+			const communicator = new JetBrainsCommunicator()
+			await communicator.sendMessage(message)
+			outputChannel.appendLine(`Message sent to JetBrains tools: ${message}`)
+		},
+
+		receiveMessageFromJetBrains: async () => {
+			const communicator = new JetBrainsCommunicator()
+			const message = await communicator.receiveMessage()
+			outputChannel.appendLine(`Message received from JetBrains tools: ${message}`)
+			return message
 		},
 	}
 

--- a/reified/ofac/RooCode/build.gradle.kts
+++ b/reified/ofac/RooCode/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    id("java")
+    id("org.jetbrains.intellij") version "1.13.3"
+}
+
+group = "com.roocode.intellij"
+version = "0.0.1"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("cn.hutool:hutool-all:5.8.22")
+    implementation("com.alibaba.fastjson2:fastjson2:2.0.41")
+}
+
+intellij {
+    version.set("2022.2.5")
+    type.set("IC")
+}
+
+tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
+        options.encoding = "UTF-8"
+    }
+
+    patchPluginXml {
+        sinceBuild.set("222")
+        untilBuild.set("232.*")
+    }
+
+    signPlugin {
+        certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
+        privateKey.set(System.getenv("PRIVATE_KEY"))
+        password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
+    }
+
+    publishPlugin {
+        token.set(System.getenv("PUBLISH_TOKEN"))
+    }
+}


### PR DESCRIPTION
Add full duplex communication between `roocode` in VSCode and JetBrains Community Edition tools.

* **Core Communication Integration**
  - Import `JetBrainsCommunicator` in `reified/Bao-Cline/src/core/Cline.ts`.
  - Initialize `JetBrainsCommunicator` in the constructor and disconnect in the `dispose` method.
  - Add methods for connecting, sending, and receiving messages to/from JetBrains tools in `reified/Bao-Cline/src/exports/index.ts`.

* **Extension Initialization**
  - Import `JetBrainsCommunicator` in `reified/Bao-Cline/src/extension.ts`.
  - Initialize `JetBrainsCommunicator` in the `activate` function.
  - Add commands for connecting, sending, and receiving messages to/from JetBrains tools.

* **Webview Communication**
  - Import `JetBrainsCommunicator` in `reified/Bao-Cline/src/core/webview/ClineProvider.ts`.
  - Add cases for connecting, sending, and receiving messages to/from JetBrains tools in the message handler.

* **Recommended Extensions**
  - Update `reified/Bao-Cline/.vscode/extensions.json` to include recommended extensions for JetBrains tools.

* **Build Configuration**
  - Add `reified/ofac/RooCode/build.gradle.kts` for IntelliJ plugin build configuration.

* **Documentation**
  - Add `REUSE.md` to document IntelliJ plugin functions and tools for JetBrains integration.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jnorthrup/RooCodeSuperProject/pull/1?shareId=62ef3f9d-73d6-4244-94fd-d397bcd4f6bf).